### PR TITLE
Point 'main' attr in package.json to './src/backgrid-responsiveGrid.js'

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "Backgrid-ResponsiveGrid",
   "version": "0.3.0",
   "description": "<img src=\"//benschwarz.github.io/bower-badges/badge@2x.png\" width=\"130\" height=\"30\">",
-  "main": "index.js",
+  "main": "./src/backgrid-responsiveGrid.js",
   "directories": {
     "example": "example"
   },


### PR DESCRIPTION
This fixes requiring the module in browserify.
